### PR TITLE
use ! syntax for mutating functions

### DIFF
--- a/doc/source/isotonic.rst
+++ b/doc/source/isotonic.rst
@@ -1,12 +1,15 @@
 Isotonic Regression
 ===================
 
-Each algorithm is implemented as a function that mutatates a vector of
-regressors with an optional weight vector.
+Each algorithm is implemented as both a function that mutates a vector of
+regressors with an optional weight vector or as a non-mutating version
+of the same function. As is idiomatic in Julia, we denote the mutating versions
+by a an exclamation mark (!).
 
 .. code-block:: julia
 
    isotonic_regression(y::Vector{Float64}, weights::Vector{Float64})
+   isotonic_regression!(y::Vector{Float64}, weights::Vector{Float64})
 
 There are additional overloads for the case where the weight vector is
 simply the ones vector.

--- a/src/Isotonic.jl
+++ b/src/Isotonic.jl
@@ -1,6 +1,11 @@
 module Isotonic
 
-export isotonic_regression, active_set_isotonic_regression, pooled_pava_isotonic_regression
+export isotonic_regression,
+       isotonic_regression!,
+       active_set_isotonic_regression,
+       active_set_isotonic_regression!,
+       pooled_pava_isotonic_regression,
+       pooled_pava_isotonic_regression!
 
 include("linear_pava.jl")
 include("active_set.jl")

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -17,7 +17,7 @@ function below(l::ActiveState, r::ActiveState)
     return l.weighted_label * r.weight <= l.weight * r.weighted_label
 end
 
-function active_set_isotonic_regression(y::Vector{Float64}, weights::Vector{Float64})
+function active_set_isotonic_regression!(y::Vector{Float64}, weights::Vector{Float64})
 
     n = length(y)
     if n <= 1
@@ -54,4 +54,8 @@ function active_set_isotonic_regression(y::Vector{Float64}, weights::Vector{Floa
     return y
 end
 
-active_set_isotonic_regression(y::Vector{Float64}) = active_set_isotonic_regression(y, ones(size(y, 1)))
+active_set_isotonic_regression!(y::Vector{Float64}) = active_set_isotonic_regression!(y, ones(size(y, 1)))
+
+# non-mutating versions
+active_set_isotonic_regression(y::Vector{Float64}, weights::Vector{Float64}) = active_set_isotonic_regression!(copy(y), weights)
+active_set_isotonic_regression(y::Vector{Float64}) = active_set_isotonic_regression(y, ones(size(y,1)))

--- a/src/linear_pava.jl
+++ b/src/linear_pava.jl
@@ -1,4 +1,4 @@
-function isotonic_regression(y::Vector{Float64}, weights::Vector{Float64})
+function isotonic_regression!(y::Vector{Float64}, weights::Vector{Float64})
 
     n = length(y)
     if n <= 1
@@ -44,4 +44,8 @@ function isotonic_regression(y::Vector{Float64}, weights::Vector{Float64})
     return y
 end
 
-isotonic_regression(y::Vector{Float64}) = isotonic_regression(y, ones(size(y, 1)))
+isotonic_regression!(y::Vector{Float64}) = isotonic_regression!(y, ones(size(y, 1)))
+
+# non-mutating versions
+isotonic_regression(y::Vector{Float64}, weights::Vector{Float64}) = isotonic_regression!(copy(y), weights)
+isotonic_regression(y::Vector{Float64}) = isotonic_regression(y, ones(size(y,1)))

--- a/src/pooled_pava.jl
+++ b/src/pooled_pava.jl
@@ -1,4 +1,4 @@
-function pooled_pava_isotonic_regression(y::Vector{Float64}, weights::Vector{Float64})
+function pooled_pava_isotonic_regression!(y::Vector{Float64}, weights::Vector{Float64})
 
     n = length(y)
     if n <= 1
@@ -34,4 +34,8 @@ function pooled_pava_isotonic_regression(y::Vector{Float64}, weights::Vector{Flo
     return y
 end
 
-pooled_pava_isotonic_regression(y::Vector{Float64}) = pooled_pava_isotonic_regression(y, ones(size(y, 1)))
+pooled_pava_isotonic_regression!(y::Vector{Float64}) = pooled_pava_isotonic_regression!(y, ones(size(y, 1)))
+
+# non-mutating versions
+pooled_pava_isotonic_regression(y::Vector{Float64}, weights::Vector{Float64}) = pooled_pava_isotonic_regression!(copy(y), weights)
+pooled_pava_isotonic_regression(y::Vector{Float64}) = pooled_pava_isotonic_regression(y, ones(size(y,1)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,25 @@ using Base.Test
 ys = map(Float64, [1, 41, 51, 1, 2, 5, 24])
 ws = map(Float64, [1, 2, 3, 4, 5, 6, 7])
 expected = [1.0, 13.95, 13.95, 13.95, 13.95, 13.95, 24]
-for f in [pooled_pava_isotonic_regression, isotonic_regression, active_set_isotonic_regression]
+
+iso_dict = Dict(:PooledPava => (pooled_pava_isotonic_regression, pooled_pava_isotonic_regression!),
+                :LinearPava => (isotonic_regression, isotonic_regression!),
+                :ActiveSet  => (active_set_isotonic_regression, active_set_isotonic_regression!))
+
+for ( k,v ) in iso_dict
+    println(k)
+    f  = v[1]
+    f! = v[2]
     @test all(abs(f(ys, ws) .- expected) .< 0.01)
 
+    # test if non-mutating or mutating
+    @test f(ys, ws) == f!(copy(ys),ws)
+    ys_copy = copy(ys)
+    fys = f(ys_copy,ws)
+    @test ys==ys_copy
+    fmut_ys = f!(ys_copy, ws)
+    @test ys != ys_copy
+    @test ys_copy == fmut_ys
     # Additional tests originally from MultipleTesting.jl package:
 
     #pooled adjacent violators example page 10 robertson
@@ -27,4 +43,3 @@ for f in [pooled_pava_isotonic_regression, isotonic_regression, active_set_isoto
     @test f(r, ones(r)) == f(r)
     @test_throws DimensionMismatch f(rand(10), ones(5))
 end
-


### PR DESCRIPTION
Hello again and sorry for the spam.

In the previous pull request (#1), I failed to notice that the functions mutate the input vector `y`. According to Julia conventions, I have now changed their name to include a `!` (e.g. `isotonic_regression!`). I have also added non-mutating variants of these functions.

Cheers,
Nikos
