### PR TITLE
fix all errors and warnings on Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.7
+julia 0.7-alpha

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.7

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -1,4 +1,4 @@
-immutable ActiveState
+struct ActiveState
     weighted_label::Float64
     weight::Float64
     lower::Int64
@@ -48,7 +48,7 @@ function active_set_isotonic_regression!(y::Vector{Float64}, weights::Vector{Flo
         end
 
         for as in active_set
-            y[as.lower:as.upper] = as.weighted_label / as.weight
+            y[as.lower:as.upper] .= as.weighted_label / as.weight
         end
     end
     return y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Isotonic
-using Base.Test
+using Test
 
 ys = map(Float64, [1, 41, 51, 1, 2, 5, 24])
 ws = map(Float64, [1, 2, 3, 4, 5, 6, 7])
@@ -13,7 +13,7 @@ for ( k,v ) in iso_dict
     println(k)
     f  = v[1]
     f! = v[2]
-    @test all(abs(f(ys, ws) .- expected) .< 0.01)
+    @test all(abs.(f(ys, ws) .- expected) .< 0.01)
 
     # test if non-mutating or mutating
     @test f(ys, ws) == f!(copy(ys),ws)
@@ -26,12 +26,12 @@ for ( k,v ) in iso_dict
     # Additional tests originally from MultipleTesting.jl package:
 
     #pooled adjacent violators example page 10 robertson
-    @test_approx_eq f([22.5; 23.333; 20.833; 24.25], [3.0;3.0;3.0;2.0]) [22.222; 22.222; 22.222; 24.25]
+    @test f([22.5; 23.333; 20.833; 24.25], [3.0;3.0;3.0;2.0]) ≈ [22.222; 22.222; 22.222; 24.25]
 
     #if input already ordered, then output should be the same
-    @test_approx_eq f([1.0; 2.0; 3.0]) [1.0; 2.0; 3.0]
+    @test f([1.0; 2.0; 3.0]) ≈ [1.0; 2.0; 3.0]
 
-    @test_approx_eq f([1., 41., 51., 1., 2., 5., 24.], [1., 2., 3., 4., 5., 6., 7.]) [1.0, 13.95, 13.95, 13.95, 13.95, 13.95, 24]
+    @test f([1., 41., 51., 1., 2., 5., 24.], [1., 2., 3., 4., 5., 6., 7.]) ≈ [1.0, 13.95, 13.95, 13.95, 13.95, 13.95, 24]
 
     # single value or empty vector remains unchanged
     r = rand(1)
@@ -40,6 +40,6 @@ for ( k,v ) in iso_dict
     @test f(r) == r
 
     r = rand(10)
-    @test f(r, ones(r)) == f(r)
+    @test f(r, fill!(similar(r), 1)) == f(r)
     @test_throws DimensionMismatch f(rand(10), ones(5))
 end


### PR DESCRIPTION
Happy [Upgradathon Friday](https://discourse.julialang.org/t/ann-introducing-upgradathon-fridays/12047)! 

This PR fixes all the test errors and deprecation warnings on Julia v0.7. It also bumps the minimum Julia version to v0.7. All of the changes are pretty minor. 